### PR TITLE
Fix of missing initalization of storeEnhancers

### DIFF
--- a/src/components/ngRedux.js
+++ b/src/components/ngRedux.js
@@ -31,7 +31,7 @@ export default function ngReduxProvider() {
 
     _reducer = reducer;
     _reducerIsObject = isObject(reducer);
-    _storeEnhancers = storeEnhancers
+    _storeEnhancers = storeEnhancers = [];
     _middlewares = middlewares || [];
     _initialState = initialState;
   };


### PR DESCRIPTION
When user did not provide storeEnhancers attribute within createStoreWith method, application was throwing an error as there was unexpected execution of "map" function on undefined element.